### PR TITLE
Fix misplaced semicolon in bah.libcurl

### DIFF
--- a/libcurl.mod/src/ares/ares_build.h
+++ b/libcurl.mod/src/ares/ares_build.h
@@ -203,7 +203,7 @@
 #    define CARES_TYPEOF_ARES_SSIZE_T long
 #  endif
 #else
-#  define CARES_TYPEOF_ARES_SSIZE_T ssize_t;
+#  define CARES_TYPEOF_ARES_SSIZE_T ssize_t
 #endif
 
 typedef CARES_TYPEOF_ARES_SSIZE_T ares_ssize_t;


### PR DESCRIPTION
A semicolon in a #define statement prevented compilation of bah.libcurl on non-windows platforms